### PR TITLE
Fix unexpected keyword end

### DIFF
--- a/lib/codic_caller.rb
+++ b/lib/codic_caller.rb
@@ -11,7 +11,6 @@ module CodicCaller
       @token = ENV['CODIC']
 
       p "please write 'export CODIC=you_access_token' in .*rc" and exit(1) if @token.nil?
-      end
     end
 
     def translate(text, casing: 'lower underscore')


### PR DESCRIPTION
When I run `$ codic t 認証`, I saw an error.

``` bash
$ codic t 認証
```

```
codic_caller-0.1.2/lib/codic_caller.rb:47: syntax error, unexpected keyword_end, expecting end-of-input (SyntaxError)
```
